### PR TITLE
RTM report in HTML format added

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,6 +4,7 @@ name := "tmt-test-reporter"
 
 libraryDependencies += "org.scalatest" %% "scalatest"        % "3.1.0"
 libraryDependencies += "net.aichler"   % "jupiter-interface" % "0.8.3" % Provided
+libraryDependencies += "com.lihaoyi" %% "scalatags" % "0.8.2"
 
 val enableFatalWarnings: SettingKey[Boolean] = settingKey[Boolean]("enable fatal warnings")
 

--- a/src/main/scala/tmt/test/reporter/TestReporter.scala
+++ b/src/main/scala/tmt/test/reporter/TestReporter.scala
@@ -3,17 +3,25 @@ package tmt.test.reporter
 import org.scalatest.Reporter
 import org.scalatest.events._
 
+object TestStatus {
+  var PASSED = "PASSED"
+  val FAILED = "FAILED"
+  val IGNORED = "IGNORED"
+  val PENDING = "PENDING"
+  val CANCELED = "CANCELED"
+}
+
 class TestReporter extends Reporter {
   var results: List[StoryResult] = List.empty
   private val parentPath         = (sys.env ++ sys.props).getOrElse("RTM_PATH", "./target/RTM")
   private val reportFile         = (sys.env ++ sys.props).getOrElse("OUTPUT_FILE", "/testStoryMapping.txt")
   override def apply(event: Event): Unit = {
     event match {
-      case x: TestSucceeded => addResult(x.testName, "PASSED")
-      case x: TestFailed    => addResult(x.testName, "FAILED")
-      case x: TestIgnored   => addResult(x.testName, "IGNORED")
-      case x: TestPending   => addResult(x.testName, "PENDING")
-      case x: TestCanceled  => addResult(x.testName, "CANCELED")
+      case x: TestSucceeded => addResult(x.testName, TestStatus.PASSED)
+      case x: TestFailed    => addResult(x.testName, TestStatus.FAILED)
+      case x: TestIgnored   => addResult(x.testName, TestStatus.IGNORED)
+      case x: TestPending   => addResult(x.testName, TestStatus.PENDING)
+      case x: TestCanceled  => addResult(x.testName, TestStatus.CANCELED)
       case _: RunCompleted  => CommonUtil.generateReport(parentPath, reportFile, results)
       case _                =>
       //    case RunStarting(ordinal, testCount, configMap, formatter, location, payload, threadName, timeStamp) =>

--- a/src/main/scala/tmt/test/reporter/TestRequirementMapper.scala
+++ b/src/main/scala/tmt/test/reporter/TestRequirementMapper.scala
@@ -3,10 +3,9 @@ package tmt.test.reporter
 import java.io.{File, FileWriter}
 import java.nio.file.Files
 import java.util.Calendar
-
 import scala.jdk.CollectionConverters.CollectionHasAsScala
 import tmt.test.reporter.Separators._
-import scalatags.Text.all._
+import scalatags.Text.all.{br, _}
 
 object TestRequirementMapper {
 
@@ -101,6 +100,9 @@ object TestRequirementMapper {
               a(name := storyId)(storyId)
             ),
             p("Requirements: ", testResults(0).reqNum.replaceAllLiterally(",", ", ")),
+            p(
+              "JIRA link: ", a(href := "https://tmt-project.atlassian.net/browse/" + storyId, target := "_blank")(storyId)
+            ),
             p("Tests:"),
             table(width := "50%")(
               tr(
@@ -114,7 +116,8 @@ object TestRequirementMapper {
             ),
             p(
               a(href := "#toc")("back to top")
-            )
+            ),
+            hr(),
           ),
         )
       ).writeTo(writer)


### PR DESCRIPTION
Our requirements verification process (VCRM report) requires automated tests to be traceable back to stories and then to requirements. We have a CSV generated by RTM-tool, it looks good but we need to have tests listed per story and to be referenceable. 

This PR includes changes needed to map VCRM to test-results per story:
- sort existing CSV by story ID to improve readability
- use https://github.com/lihaoyi/scalatags for constructing HTML files
- generate RTM report in HTML format with data grouped by story ID

We need to keep this HTML as an artifact per CI-flow run. Also, this report will be generated by Jenkins during the acceptance testing on BTE as part of the TMT release process.

Then, this RTM-report will be uploaded by CI-flow to some web-resource so we can put URLs into the VCRM report pointing to tests-results per story. 
