### PR TITLE
adding orange color for tests with status different from failed or p…

### DIFF
--- a/src/main/scala/tmt/test/reporter/TestRequirementMapper.scala
+++ b/src/main/scala/tmt/test/reporter/TestRequirementMapper.scala
@@ -90,8 +90,9 @@ object TestRequirementMapper {
               td(
                 a(href := "#" + storyId)(storyId)
               ),
-              td(testResults(0).reqNum.replaceAllLiterally(",", ", ")),
-              if (testResults.count(t => t.status == TestStatus.PASSED) != testResults.length) td(color:="red")(TestStatus.FAILED)
+              td(testResults(0).reqNum.replace(",", ", ")),
+              if (testResults.count(t => t.status.toUpperCase == TestStatus.FAILED) > 0) td(color:="red")(TestStatus.FAILED)
+              else if (testResults.count(t => t.status.toUpperCase != TestStatus.PASSED) > 0) td(color:="orange")(TestStatus.FAILED)
               else td(color:="green")(TestStatus.PASSED)
             )
           ),
@@ -99,7 +100,7 @@ object TestRequirementMapper {
             h3(
               a(name := storyId)(storyId)
             ),
-            p("Requirements: ", testResults(0).reqNum.replaceAllLiterally(",", ", ")),
+            p("Requirements: ", testResults(0).reqNum.replace(",", ", ")),
             p(
               "JIRA link: ", a(href := "https://tmt-project.atlassian.net/browse/" + storyId, target := "_blank")(storyId)
             ),
@@ -111,7 +112,9 @@ object TestRequirementMapper {
               ),
               for (testRes <- testResults) yield tr(
                 td(testRes.test),
-                if (testRes.status != TestStatus.PASSED) td(color:="red")(testRes.status) else td(color:="green")(testRes.status)
+                if (testRes.status.toUpperCase == TestStatus.FAILED) td(color:="red")(TestStatus.FAILED)
+                else if (testRes.status.toUpperCase == TestStatus.PASSED) td(color:="green")(TestStatus.PASSED)
+                else td(color:="orange")(testRes.status.toUpperCase)
               )
             ),
             p(


### PR DESCRIPTION
…assed

This PR includes changes to show in orange color:
- tests with status different from FAILED or PASSED, also the real status is shown (not just PASSED or FAILED)
- stories will have status as orange FAILED if assigned tests have PASSED status and and some other status but not FAILED (i.e. SKIPPED)
- if a story has at least one test with FAILED status then it will have status FAILED in read color

Please see the attachments as example.

[testStoryMapping.txt](https://github.com/tmtsoftware/rtm/files/7011870/testStoryMapping.txt)

<img width="974" alt="Screen Shot 2021-08-18 at 4 19 39 PM" src="https://user-images.githubusercontent.com/33698537/130011710-73de4e0d-3295-4db7-87b3-faf514aa492c.png">
<img width="969" alt="Screen Shot 2021-08-18 at 4 19 54 PM" src="https://user-images.githubusercontent.com/33698537/130011716-029857e4-b113-40a8-9d1d-3887fbbbb1a0.png">
<img width="967" alt="Screen Shot 2021-08-18 at 4 20 10 PM" src="https://user-images.githubusercontent.com/33698537/130011721-8ff0c888-6823-4c2f-bac7-6c30ce58506b.png">

